### PR TITLE
feat(tools): add PATH search and async wasm-opt run

### DIFF
--- a/src/Brim.Binaryen/Tools/BinaryenToolLocator.cs
+++ b/src/Brim.Binaryen/Tools/BinaryenToolLocator.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Brim.Binaryen.Tools;
 
@@ -12,10 +14,21 @@ public sealed class BinaryenToolLocator : IBinaryenToolLocator
   public string Resolve(string toolName)
   {
     string exe = OperatingSystem.IsWindows() ? $"{toolName}.exe" : toolName;
-    string path = Path.Combine(AppContext.BaseDirectory, exe);
-    return !File.Exists(path)
-      ? throw new FileNotFoundException($"Binaryen tool not found: {path}")
-      : path;
+    string baseDirPath = Path.Combine(AppContext.BaseDirectory, exe);
+    if (File.Exists(baseDirPath)) return baseDirPath;
+
+    string? pathEnv = Environment.GetEnvironmentVariable("PATH");
+    if (!string.IsNullOrEmpty(pathEnv))
+    {
+      foreach (string dir in pathEnv.Split(Path.PathSeparator))
+      {
+        if (string.IsNullOrWhiteSpace(dir)) continue;
+        string candidate = Path.Combine(dir, exe);
+        if (File.Exists(candidate)) return candidate;
+      }
+    }
+
+    throw new FileNotFoundException($"Binaryen tool not found: {exe}");
   }
 }
 
@@ -35,5 +48,26 @@ public static class WasmOpt
     stderr = p.StandardError.ReadToEnd();
     p.WaitForExit();
     return p.ExitCode;
+  }
+
+  public static async Task<(int exitCode, string stdout, string stderr)> RunAsync(
+    IBinaryenToolLocator locator,
+    string args,
+    CancellationToken cancellationToken)
+  {
+    ProcessStartInfo psi = new(locator.Resolve("wasm-opt"))
+    {
+      Arguments = args,
+      RedirectStandardOutput = true,
+      RedirectStandardError = true
+    };
+
+    using Process p = Process.Start(psi)!;
+    Task<string> stdoutTask = p.StandardOutput.ReadToEndAsync(cancellationToken);
+    Task<string> stderrTask = p.StandardError.ReadToEndAsync(cancellationToken);
+    await p.WaitForExitAsync(cancellationToken);
+    string stdout = await stdoutTask;
+    string stderr = await stderrTask;
+    return (p.ExitCode, stdout, stderr);
   }
 }

--- a/tests/Brim.Binaryen.Tests/BinaryenToolLocatorTests.cs
+++ b/tests/Brim.Binaryen.Tests/BinaryenToolLocatorTests.cs
@@ -1,0 +1,70 @@
+using Brim.Binaryen.Tools;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Brim.Binaryen.Tests;
+
+public class BinaryenToolLocatorTests
+{
+  [Fact]
+  public void Resolve_Finds_Tool_On_Path()
+  {
+    if (OperatingSystem.IsWindows())
+    {
+      BinaryenToolLocator locator = new();
+      string path = locator.Resolve("dotnet");
+      Assert.True(File.Exists(path));
+      return;
+    }
+
+    string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+    Directory.CreateDirectory(tempDir);
+    string toolName = "dummy";
+    string toolPath = Path.Combine(tempDir, toolName);
+    File.WriteAllText(toolPath, "#!/bin/sh\nexit 0\n");
+    Process.Start("chmod", $"+x {toolPath}")!.WaitForExit();
+    string? originalPath = Environment.GetEnvironmentVariable("PATH");
+    Environment.SetEnvironmentVariable("PATH", tempDir);
+    try
+    {
+      BinaryenToolLocator locator = new();
+      string resolved = locator.Resolve(toolName);
+      Assert.Equal(toolPath, resolved);
+    }
+    finally
+    {
+      Environment.SetEnvironmentVariable("PATH", originalPath);
+      Directory.Delete(tempDir, true);
+    }
+  }
+
+  [Fact]
+  public async Task RunAsync_Executes_Command()
+  {
+    IBinaryenToolLocator locator;
+    string args;
+    if (OperatingSystem.IsWindows())
+    {
+      locator = new StubLocator(Path.Combine(Environment.SystemDirectory, "cmd.exe"));
+      args = "/c \"echo stdout && echo stderr 1>&2\"";
+    }
+    else
+    {
+      locator = new StubLocator("/bin/sh");
+      args = "-c \"echo stdout; echo stderr 1>&2\"";
+    }
+
+    (int exitCode, string stdout, string stderr) = await WasmOpt.RunAsync(locator, args, CancellationToken.None);
+    Assert.Equal(0, exitCode);
+    Assert.Contains("stdout", stdout);
+    Assert.Contains("stderr", stderr);
+  }
+
+  private sealed class StubLocator : IBinaryenToolLocator
+  {
+    private readonly string _path;
+    public StubLocator(string path) => _path = path;
+    public string Resolve(string toolName) => _path;
+  }
+}


### PR DESCRIPTION
## Summary
- probe `AppContext.BaseDirectory` then `PATH` when resolving tools
- add `RunAsync` for `wasm-opt` with output capture and cancellation
- test PATH-based resolution and async process execution

## Testing
- `dotnet test --filter BinaryenToolLocatorTests`
- `dotnet test` *(fails: Binaryen native library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d53e7e84832eaae02e0157765e37